### PR TITLE
Fix zipcode dropdown styling

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -85,15 +85,16 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   async function populateZipcodeList() {
-    const datalist = document.getElementById('zipcode-list');
-    if (!datalist) return;
+    const select = document.getElementById('zipcode-select');
+    if (!select) return;
     const data = await loadDistrictData();
     const set = new Set();
     data.forEach(row => row.slice(1).forEach(zip => set.add(zip)));
     set.forEach(z => {
       const opt = document.createElement('option');
       opt.value = z;
-      datalist.appendChild(opt);
+      opt.textContent = z;
+      select.appendChild(opt);
     });
   }
 

--- a/search.html
+++ b/search.html
@@ -38,8 +38,9 @@
     <section class="search-section">
       <h2>郵便番号から探す</h2>
       <form action="candidate_list.html" method="get">
-        <input type="text" name="zipcode" list="zipcode-list" placeholder="例: 1000000">
-        <datalist id="zipcode-list"></datalist>
+        <select name="zipcode" id="zipcode-select">
+          <option value="">選択してください</option>
+        </select>
         <button type="submit">検索</button>
       </form>
     </section>


### PR DESCRIPTION
## Summary
- make zipcode selector a `<select>` element instead of text input
- update script to populate the new select element

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684aa98047008329ae359f3d2c440b10