### PR TITLE
Add Unification Church relation filter and summary

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -85,3 +85,9 @@ button:hover {
 .search-section {
   margin-bottom: 1.5rem;
 }
+
+/* highlight relation to Unification Church on list page */
+.relation.has-relation {
+  color: red;
+  font-weight: bold;
+}

--- a/js/script.js
+++ b/js/script.js
@@ -2,8 +2,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const params = new URLSearchParams(window.location.search);
   const condition = document.getElementById('condition');
   if (condition) {
-    const condText = ['party', 'district']
-      .map(k => params.get(k) ? `${k}: ${params.get(k)}` : null)
+    const condText = ['party', 'district', 'relation']
+      .map(k => {
+        if (!params.get(k)) return null;
+        if (k === 'relation') return '統一教会との関わり報道あり';
+        return `${k}: ${params.get(k)}`;
+      })
       .filter(Boolean)
       .join(', ');
     condition.textContent = condText || '指定なし';
@@ -107,6 +111,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const candidates = (await loadCandidates()).filter(c => {
       if (params.get('party') && c.party !== params.get('party')) return false;
       if (params.get('district') && c.district !== params.get('district')) return false;
+      if (params.get('relation') === 'true' && !c.relation) return false;
       return true;
     });
     candidates.forEach(c => {
@@ -117,6 +122,7 @@ document.addEventListener('DOMContentLoaded', () => {
         <p>政党: ${c.party}</p>
         <p>選挙区: ${c.district}</p>
         <p>年齢: ${c.age}</p>
+        <p class="relation ${c.relation ? 'has-relation' : ''}">統一教会との関わり報道: ${c.relation ? 'あり' : 'なし'}</p>
         <p><a href="candidate_detail.html?id=${c.id}">詳細</a></p>
       `;
       list.appendChild(div);

--- a/search.html
+++ b/search.html
@@ -35,6 +35,13 @@
         <button type="submit">検索</button>
       </form>
     </section>
+    <section class="search-section">
+      <h2>統一教会との関わりが報道された候補者</h2>
+      <form action="candidate_list.html" method="get">
+        <input type="hidden" name="relation" value="true">
+        <button type="submit">表示</button>
+      </form>
+    </section>
   </main>
   <footer>
     <p>&copy; 2025 都議選候補者情報サイト</p>


### PR DESCRIPTION
## Summary
- show search condition for candidates linked to the Unification Church
- filter candidate list by the `relation=true` query parameter
- display relation summary in each candidate card and highlight if reported
- add a button on the search page for candidates with reported ties
- add style for highlighting relation status

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684abec4cfcc83299704355e1b622bb7