### PR TITLE
Remove 'none' label for Unification Church link

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -122,7 +122,7 @@ document.addEventListener('DOMContentLoaded', () => {
         <p>政党: ${c.party}</p>
         <p>選挙区: ${c.district}</p>
         <p>年齢: ${c.age}</p>
-        <p class="relation ${c.relation ? 'has-relation' : ''}">統一教会との関わり報道: ${c.relation ? 'あり' : 'なし'}</p>
+        ${c.relation ? `<p class="relation has-relation">統一教会との関わり報道: あり</p>` : ''}
         <p><a href="candidate_detail.html?id=${c.id}">詳細</a></p>
       `;
       list.appendChild(div);


### PR DESCRIPTION
## Summary
- omit '統一教会との関わり報道: なし' from candidate lists when no info is available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d367e66088329a57032e40688a009